### PR TITLE
Feat return gotrue api content in exception object

### DIFF
--- a/Gotrue/Client.cs
+++ b/Gotrue/Client.cs
@@ -493,7 +493,7 @@ namespace Supabase.Gotrue
                     Debug.WriteLine(ex.Message);
                     return new UnauthorizedException(ex);
                 case System.Net.HttpStatusCode.BadRequest:
-                    Debug.WriteLine("Bad Request, this is may be a user that has not confirmed their email.");
+                    Debug.WriteLine(ex.Message);
                     return new BadRequestException(ex);
                 case System.Net.HttpStatusCode.Forbidden:
                     Debug.WriteLine("Forbidden, are sign-ups disabled?");
@@ -560,45 +560,57 @@ namespace Supabase.Gotrue
     public class UnauthorizedException : Exception
     {
         public HttpResponseMessage Response { get; private set; }
+
+        public string Content { get; private set; }
         public UnauthorizedException(RequestException exception)
         {
             Response = exception.Response;
+            Content = exception.Error.Message;
         }
     }
 
     public class BadRequestException : Exception
     {
         public HttpResponseMessage Response { get; private set; }
+
+        public string Content { get; private set; }
         public BadRequestException(RequestException exception)
         {
             Response = exception.Response;
+            Content = exception.Error.Message;
         }
     }
 
     public class ForbiddenException : Exception
     {
         public HttpResponseMessage Response { get; private set; }
+        public string Content { get; private set; }
         public ForbiddenException(RequestException exception)
         {
             Response = exception.Response;
+            Content = exception.Error.Message;
         }
     }
 
     public class InvalidEmailOrPasswordException : Exception
     {
         public HttpResponseMessage Response { get; private set; }
+        public string Content { get; private set; }
         public InvalidEmailOrPasswordException(RequestException exception)
         {
             Response = exception.Response;
+            Content = exception.Error.Message;
         }
     }
 
     public class ExistingUserException : Exception
     {
         public HttpResponseMessage Response { get; private set; }
+        public string Content { get; private set; }
         public ExistingUserException(RequestException exception)
         {
             Response = exception.Response;
+            Content = exception.Error.Message;
         }
     }
 }

--- a/Gotrue/Helpers.cs
+++ b/Gotrue/Helpers.cs
@@ -93,7 +93,11 @@ namespace Supabase.Gotrue
                         obj = new ErrorResponse { Message = "Invalid or Empty response received. Are you trying to update or delete a record that does not exist?", ResponseMessage = response };
                     }
 
-                    obj.Content = content;
+                    obj = new ErrorResponse
+                    {
+                        Content = content,
+                        Message = content
+                    };
                     throw new RequestException(response, obj);
                 }
                 else

--- a/GotrueTests/Api.cs
+++ b/GotrueTests/Api.cs
@@ -15,6 +15,8 @@ namespace GotrueTests
         private string password = "I@M@SuperP@ssWord";
 
         private static Random random = new Random();
+
+
         private static string RandomString(int length)
         {
             const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
@@ -26,16 +28,30 @@ namespace GotrueTests
         public async Task TestInitializer()
         {
             client = await Initialize();
+
         }
 
         [TestMethod("Client: Signs Up User")]
         public async Task ClientSignsUpUser()
         {
-            var result = await client.SignUp($"{RandomString(12)}@supabase.io", password);
+            var email = $"{RandomString(12)}@supabase.io";
+            var result = await client.SignUp(email, password);
 
             Assert.IsNotNull(result.AccessToken);
             Assert.IsNotNull(result.RefreshToken);
             Assert.IsInstanceOfType(result.User, typeof(User));
+        }
+
+        [TestMethod("Client: Signs Up the same user twice should throw an error")]
+        public async Task ClientSignsUpUserTwiceShouldThrowError()
+        {
+            var email = $"{RandomString(12)}@supabase.io";
+            await client.SignUp(email, password);
+            await Assert.ThrowsExceptionAsync<BadRequestException>(async () =>
+            {
+                var result = await client.SignUp(email, password);
+            });
+
         }
 
         [TestMethod("Client: Signs In User with Email & Password")]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature #1 

## What is the current behavior?

When Gotrue API return a non success code an exception is thrown and the exception object doesn't contain the Gotrue API content

## What is the new behavior?

for example if some user already signed up and tries to sign up again to catch the exception :
```csharp
try
{
var result = await client.SignUp("existing@supabase.io", "PA$$WORD$*");
}
catch (Exception ex)
{
   // Can retrieve the Gotrue API message
   Debug.WriteLine(ex.Message);
}
```

## Additional context

Can access the Exception message also if he catch the exact exception type for example :
```csharp
catch(BadRequestException ex)
{
    Debug.WriteLine(ex.Content)
}
```
