### PR TITLE
Fix update user

### DIFF
--- a/Gotrue/Api.cs
+++ b/Gotrue/Api.cs
@@ -144,7 +144,7 @@ namespace Supabase.Gotrue
         /// <returns></returns>
         public Task<User> UpdateUser(string jwt, UserAttributes attributes)
         {
-            return Helpers.MakeRequest<User>(HttpMethod.Put, $"{Url}/recover", attributes, CreateAuthedRequestHeaders(jwt));
+            return Helpers.MakeRequest<User>(HttpMethod.Put, $"{Url}/user", attributes, CreateAuthedRequestHeaders(jwt));
         }
 
         /// <summary>

--- a/GotrueTests/Api.cs
+++ b/GotrueTests/Api.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
 using Supabase.Gotrue;
 using static Supabase.Gotrue.Client;
 
@@ -86,6 +88,24 @@ namespace GotrueTests
         {
             var result = await client.SignIn(Provider.Google);
             Assert.AreEqual("http://localhost:9999/authorize?provider=google", result);
+        }
+
+        [TestMethod("Client: Update user")]
+        public async Task ClientUpdateUser()
+        {
+            var user = $"{RandomString(12)}@supabase.io";
+            await client.SignUp(user, password);
+
+            var attributes = new UserAttributes
+            {
+                Data = new Dictionary<string, object>
+                {
+                    {"hello", "world" }
+                }
+            };
+            await client.Update(attributes);
+            Assert.AreEqual(user, client.CurrentUser.Email);
+            Assert.IsNotNull(client.CurrentUser.UserMetadata);
         }
     }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?
Hello,
Bug fix #3 

## What is the current behavior?

* A request is send to wrong route **"/recover"** instead of **"/user"**

## What is the new behavior?

* Send a request to "/user" to update a user

Thank you.
