### PR TITLE
Feat InviteUserByEmail

### DIFF
--- a/Gotrue/Api.cs
+++ b/Gotrue/Api.cs
@@ -65,11 +65,12 @@ namespace Supabase.Gotrue
         /// Sends an invite link to an email address.
         /// </summary>
         /// <param name="email"></param>
+        /// <param name="jwt">this token needs role 'supabase_admin' or 'service_role'</param>
         /// <returns></returns>
-        public Task<BaseResponse> InviteUserByEmail(string email)
+        public Task<BaseResponse> InviteUserByEmail(string email, string jwt)
         {
             var data = new Dictionary<string, string> { { "email", email } };
-            return Helpers.MakeRequest(HttpMethod.Post, $"{Url}/invite", data, Headers);
+            return Helpers.MakeRequest(HttpMethod.Post, $"{Url}/invite", data,  CreateAuthedRequestHeaders(jwt));
         }
 
         /// <summary>

--- a/Gotrue/Client.cs
+++ b/Gotrue/Client.cs
@@ -326,11 +326,11 @@ namespace Supabase.Gotrue
         /// </summary>
         /// <param name="email"></param>
         /// <returns></returns>
-        public async Task<bool> InviteUserByEmail(string email)
+        public async Task<bool> InviteUserByEmail(string email,string jwt)
         {
             try
             {
-                var response = await api.InviteUserByEmail(email);
+                var response = await api.InviteUserByEmail(email, jwt);
                 response.ResponseMessage.EnsureSuccessStatusCode();
                 return true;
             }

--- a/Gotrue/Client.cs
+++ b/Gotrue/Client.cs
@@ -320,6 +320,25 @@ namespace Supabase.Gotrue
                 throw ParseRequestException(ex);
             }
         }
+        
+        /// <summary>
+        /// Sends an invite email link to the specified email.
+        /// </summary>
+        /// <param name="email"></param>
+        /// <returns></returns>
+        public async Task<bool> InviteUserByEmail(string email)
+        {
+            try
+            {
+                var response = await api.InviteUserByEmail(email);
+                response.ResponseMessage.EnsureSuccessStatusCode();
+                return true;
+            }
+            catch (RequestException ex)
+            {
+                throw ParseRequestException(ex);
+            }
+        }
 
         /// <summary>
         /// Refreshes the currently logged in User's Session.

--- a/GotrueTests/Api.cs
+++ b/GotrueTests/Api.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
+using Microsoft.IdentityModel.Tokens;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Newtonsoft.Json;
 using Supabase.Gotrue;
 using static Supabase.Gotrue.Client;
 
@@ -21,9 +23,32 @@ namespace GotrueTests
 
         private static string RandomString(int length)
         {
-            const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+            const string chars = "abcdefghijklmnopqrstuvwxyz0123456789";
             return new string(Enumerable.Repeat(chars, length)
               .Select(s => s[random.Next(s.Length)]).ToArray());
+        }
+        
+        private string GenerateServiceRoleToken()
+        {
+            var signingKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes("37c304f8-51aa-419a-a1af-06154e63707a")); // using GOTRUE_JWT_SECRET
+
+            var tokenDescriptor = new SecurityTokenDescriptor
+            {
+                IssuedAt = DateTime.Now,
+                Expires = DateTime.UtcNow.AddDays(7),
+                SigningCredentials =
+                    new SigningCredentials(signingKey, SecurityAlgorithms.HmacSha256Signature),
+                Claims = new Dictionary<string, object>()
+                {
+                    {
+                        "role", "service_role"
+                    }
+                }
+            };
+            
+            var tokenHandler = new JwtSecurityTokenHandler();
+            var securityToken = tokenHandler.CreateToken(tokenDescriptor);
+            return tokenHandler.WriteToken(securityToken);
         }
 
         [TestInitialize]
@@ -158,8 +183,8 @@ namespace GotrueTests
         public async Task ClientSendsInviteEmail()
         {
             var user = $"{RandomString(12)}@supabase.io";
-            
-            var result = await client.InviteUserByEmail(user);
+            var service_role_key = GenerateServiceRoleToken();
+            var result = await client.InviteUserByEmail(user, service_role_key);
             Assert.IsTrue(result);
         }
     }

--- a/GotrueTests/Api.cs
+++ b/GotrueTests/Api.cs
@@ -153,5 +153,14 @@ namespace GotrueTests
             });
 
         }
+        
+        [TestMethod("Client: Sends Invite Email")]
+        public async Task ClientSendsInviteEmail()
+        {
+            var user = $"{RandomString(12)}@supabase.io";
+            
+            var result = await client.InviteUserByEmail(user);
+            Assert.IsTrue(result);
+        }
     }
 }

--- a/GotrueTests/GotrueTests.csproj
+++ b/GotrueTests/GotrueTests.csproj
@@ -8,12 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
     <PackageReference Include="coverlet.collector" Version="3.0.3"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>
 </PackageReference>
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.12.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds the invite user by email functionality to the client

## What is the current behavior?

Although implemented in the api the method isn't exposed on the client and you can't pass in a service_role token/secret

## What is the new behavior?

Exposed the invite user by email method on the client, allowing a user to specify a jwt from the client.

## Additional context

The random string method in the test suite used to generate emails was causing tests to fail as they were generating uppercase email and GoTrue is returning them as lowercase
