### PR TITLE
Fix RefreshToken()

### DIFF
--- a/Gotrue/Client.cs
+++ b/Gotrue/Client.cs
@@ -712,9 +712,6 @@ namespace Supabase.Gotrue
 			if (CurrentSession == null || string.IsNullOrEmpty(CurrentSession?.AccessToken) || string.IsNullOrEmpty(CurrentSession?.RefreshToken))
 				throw new GotrueException("No current session.", NoSessionFound);
 
-			if (CurrentSession!.Expired())
-				throw new GotrueException("Session expired", ExpiredRefreshToken);
-
 			var result = await _api.RefreshAccessToken(CurrentSession.AccessToken!, CurrentSession.RefreshToken!);
 
 			if (result == null || string.IsNullOrEmpty(result.AccessToken))


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refresh token never expires. Don't need to check for session expiration when refreshing.
This fixes a bug making it impossible to recover a session after the client has been offline for longer than the expiry time of the access token.

## What is the current behavior?

Can't use a refresh token beyond the expiry time of the access token.

## What is the new behavior?

Client can now try to refresh the access token for as long as it holds the refresh token.