### PR TITLE
Introduce LoadSessionAsync for async scenarios

### DIFF
--- a/Gotrue/Client.cs
+++ b/Gotrue/Client.cs
@@ -68,7 +68,7 @@ namespace Supabase.Gotrue
 		/// <remarks></remarks>
 		/// <example>
 		///		var client = new Supabase.Gotrue.Client(options);
-		///     client.LoadSession();
+		///		await client.LoadSessionAsync();
 		///		await client.RetrieveSessionAsync();
 		/// </example>
 		/// </summary>
@@ -725,11 +725,18 @@ namespace Supabase.Gotrue
 			NotifyAuthStateChange(TokenRefreshed);
 		}
 
-
 		/// <inheritdoc />
+		[Obsolete("Call LoadSessionAsync instead.")]
 		public void LoadSession()
 		{
 			if (_sessionPersistence != null) UpdateSession(_sessionPersistence.Persistence.LoadSession());
+		}
+		
+		/// <inheritdoc />
+		public async Task LoadSessionAsync()
+		{
+			if (_sessionPersistence != null) 
+				UpdateSession(await _sessionPersistence.Persistence.LoadSessionAsync());
 		}
 
 

--- a/Gotrue/Gotrue.csproj
+++ b/Gotrue/Gotrue.csproj
@@ -16,8 +16,8 @@
         <PackageIconUrl>https://avatars.githubusercontent.com/u/54469796?s=200&amp;v=4</PackageIconUrl>
         <PackageProjectUrl>https://github.com/supabase-community/gotrue-csharp</PackageProjectUrl>
         <PackageTags>supabase, gotrue</PackageTags>
-        <PackageVersion>6.0.3</PackageVersion>
-        <ReleaseVersion>6.0.3</ReleaseVersion>
+        <PackageVersion>6.0.4</PackageVersion>
+        <ReleaseVersion>6.0.4</ReleaseVersion>
         <RepositoryUrl>https://github.com/supabase-community/gotrue-csharp</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageIcon>icon.png</PackageIcon>

--- a/Gotrue/Interfaces/IGotrueClient.cs
+++ b/Gotrue/Interfaces/IGotrueClient.cs
@@ -424,7 +424,13 @@ namespace Supabase.Gotrue.Interfaces
 		/// <summary>
 		/// Loads the session from the persistence layer.
 		/// </summary>
+		[Obsolete("Use LoadSessionAsync")]
 		void LoadSession();
+
+		/// <summary>
+		/// Loads the session asynchronously from the persistence layer.
+		/// </summary>
+		Task LoadSessionAsync();
 
 		/// <summary>
 		/// Retrieves the settings from the server

--- a/Gotrue/Interfaces/IGotrueSessionPersistence.cs
+++ b/Gotrue/Interfaces/IGotrueSessionPersistence.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Threading.Tasks;
+
 namespace Supabase.Gotrue.Interfaces
 {
 	/// <summary>
@@ -23,6 +26,13 @@ namespace Supabase.Gotrue.Interfaces
 		/// Loads the session from the persistence implementation. Returns null if there is no session.
 		/// </summary>
 		/// <returns></returns>
+		[Obsolete("Use LoadSessionAsync instead")]
 		public TSession? LoadSession();
+		
+		/// <summary>
+		/// Loads the session asynchronously from the persistence implementation. Returns null if there is no session.
+		/// </summary>
+		/// <returns></returns>
+		public Task<TSession?> LoadSessionAsync() => Task.FromResult(LoadSession());
 	}
 }

--- a/GotrueTests/AnonKeyClientTests.cs
+++ b/GotrueTests/AnonKeyClientTests.cs
@@ -95,7 +95,7 @@ namespace GotrueTests
 			newClient.AddStateChangedListener(AuthStateListener);
 
 			// Loads the session from storage
-			newClient.LoadSession();
+			await newClient.LoadSessionAsync();
 
 			Contains(_stateChanges, SignedIn);
 			AreEqual(newClient.CurrentSession, newPersistence.SavedSession);

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ async void Initialize() {
     client.AddStateChangedListener(AuthStateListener);
 
     // Load the session from persistence
-    client.LoadSession();
+    await client.LoadSessionAsync();
     // Loads the session using SessionRetriever and sets state internally.
     await client.RetrieveSessionAsync();
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Introduce the LoadSessionAsync to allow scenarios where LoadSession needs to load the session in an async way. In some cases it's not possible to load the session in a sync way, thus the introduction of this new method. I encountered a roadblock while trying to use this lib in a Blazor project, where the load session from local storage is done in an async way, and its not possible to force it to be sync.

## What is the current behavior?

Currently its not possible to load session in an async way.

## What is the new behavior?

Allow the session to be loaded asynchronously.

## Additional context

I introduced an obsolete attribute to the LoadSession methods but redirected the LoadSessionAsync implementation to the LoadSession, to avoid breaking changes on existing consumers.
New consumers that want to use LoadSessionAsync should implement that method and disregard the old one, as it should be removed in the future.
