### PR TITLE
Fix tokens not refreshing when calling RefreshToken() or RetrieveSessionAsync()

### DIFF
--- a/Gotrue/Client.cs
+++ b/Gotrue/Client.cs
@@ -595,21 +595,13 @@ namespace Supabase.Gotrue
 			if (CurrentSession == null)
 				return null;
 
-			// Check to see if the session has expired. If so go ahead and destroy it.
-			if (CurrentSession != null && CurrentSession.Expired())
-			{
-				_debugNotification?.Log($"Loaded session has expired");
-				DestroySession();
-				return null;
-			}
-
 			// If we aren't online, we can't refresh the token
 			if (!Online)
 			{
 				throw new GotrueException("Only supported when online", Offline);
 			}
 
-			// We have a session, and hasn't expired, and we seem to be online. Let's try to refresh it.
+			// We have a session, and we seem to be online. Let's try to refresh it.
 			if (Options.AutoRefreshToken && CurrentSession?.RefreshToken != null)
 			{
 				try
@@ -711,9 +703,6 @@ namespace Supabase.Gotrue
 
 			if (CurrentSession == null || string.IsNullOrEmpty(CurrentSession?.AccessToken) || string.IsNullOrEmpty(CurrentSession?.RefreshToken))
 				throw new GotrueException("No current session.", NoSessionFound);
-
-			if (CurrentSession!.Expired())
-				throw new GotrueException("Session expired", ExpiredRefreshToken);
 
 			var result = await _api.RefreshAccessToken(CurrentSession.AccessToken!, CurrentSession.RefreshToken!);
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Removed the expiry checks from RefreshToken() and RetrieveSessionAsync() to fix tokens not refreshing when access token is expired.

## What is the current behavior?

When RetrieveSessionAsync() is called the expiry is checked and assumes that the session is invalid.
The same check happens in RefreshToken() before actually trying to refresh it, causing it to never properly try to refresh the tokens.

## What is the new behavior?

If the access token has expired and AutoRefreshToken is enabled RetrieveSessionAsync() wil try to refresh the tokens.
And when manually calling RefreshToken() the method will continue to refresh the token

## Additional context

It seems like it was assumed that the expiry was for the whole session, but it is specifically for the access token.

This would close issue #108 and PR #106
