### PR TITLE
Add soft-delete option to `DeleteUser` method

### DIFF
--- a/Gotrue/AdminClient.cs
+++ b/Gotrue/AdminClient.cs
@@ -69,9 +69,9 @@ namespace Supabase.Gotrue
 		}
 
 		/// <inheritdoc />
-		public async Task<bool> DeleteUser(string uid)
+		public async Task<bool> DeleteUser(string uid, bool shouldSoftDelete = false)
 		{
-			var result = await _api.DeleteUser(uid, _serviceKey);
+			var result = await _api.DeleteUser(_serviceKey, uid, shouldSoftDelete);
 			result.ResponseMessage?.EnsureSuccessStatusCode();
 			return true;
 		}

--- a/Gotrue/Api.cs
+++ b/Gotrue/Api.cs
@@ -738,12 +738,17 @@ namespace Supabase.Gotrue
 		/// <summary>
 		/// Delete a user
 		/// </summary>
-		/// <param name="uid">The user uid you want to remove.</param>
 		/// <param name="jwt">A valid JWT. Must be a full-access API key (e.g. service_role key).</param>
+		/// <param name="uid">The user uid you want to remove.</param>
+		/// <param name="shouldSoftDelete">If true, then the user will be soft-deleted from the auth schema. Defaults to false.</param>
 		/// <returns></returns>
-		public Task<BaseResponse> DeleteUser(string uid, string jwt)
+		public Task<BaseResponse> DeleteUser(string jwt, string uid, bool shouldSoftDelete = false)
 		{
-			var data = new Dictionary<string, string>();
+			var data = new Dictionary<string, bool>
+			{
+				{ "should_soft_delete", shouldSoftDelete }
+			};
+			
 			return Helpers.MakeRequest(HttpMethod.Delete, $"{Url}/admin/users/{uid}", data, CreateAuthedRequestHeaders(jwt));
 		}
 

--- a/Gotrue/Api.cs
+++ b/Gotrue/Api.cs
@@ -740,9 +740,9 @@ namespace Supabase.Gotrue
 		/// </summary>
 		/// <param name="jwt">A valid JWT. Must be a full-access API key (e.g. service_role key).</param>
 		/// <param name="uid">The user uid you want to remove.</param>
-		/// <param name="shouldSoftDelete">If true, then the user will be soft-deleted from the auth schema. Defaults to false.</param>
+		/// <param name="shouldSoftDelete">If true, then the user will be soft-deleted.</param>
 		/// <returns></returns>
-		public Task<BaseResponse> DeleteUser(string jwt, string uid, bool shouldSoftDelete = false)
+		public Task<BaseResponse> DeleteUser(string jwt, string uid, bool shouldSoftDelete)
 		{
 			var data = new Dictionary<string, bool>
 			{

--- a/Gotrue/Interfaces/IGotrueAdminClient.cs
+++ b/Gotrue/Interfaces/IGotrueAdminClient.cs
@@ -35,7 +35,7 @@ namespace Supabase.Gotrue.Interfaces
 		/// Creates a user using the admin key (not the anonymous key).
 		/// Used in trusted server environments, not client apps.
 		/// </summary>
-		Task<bool> DeleteUser(string uid);
+		Task<bool> DeleteUser(string uid, bool shouldSoftDelete = false);
 
 		/// <summary>
 		/// Gets a user from a user's JWT. This is using the GoTrue server to validate a user's JWT.

--- a/Gotrue/Interfaces/IGotrueApi.cs
+++ b/Gotrue/Interfaces/IGotrueApi.cs
@@ -14,7 +14,7 @@ namespace Supabase.Gotrue.Interfaces
 		where TSession : Session
 	{
 		Task<TUser?> CreateUser(string jwt, AdminUserAttributes? attributes = null);
-		Task<BaseResponse> DeleteUser(string uid, string jwt);
+		Task<BaseResponse> DeleteUser(string jwt, string uid, bool shouldSoftDelete = false);
 		Task<TUser?> GetUser(string jwt);
 		Task<TUser?> GetUserById(string jwt, string userId);
 		Task<BaseResponse> InviteUserByEmail(string email, string jwt, InviteUserByEmailOptions? options = null);

--- a/Gotrue/Interfaces/IGotrueStatelessClient.cs
+++ b/Gotrue/Interfaces/IGotrueStatelessClient.cs
@@ -40,11 +40,12 @@ namespace Supabase.Gotrue.Interfaces
         /// <summary>
         /// Deletes a User.
         /// </summary>
-        /// <param name="uid"></param>
         /// <param name="serviceRoleToken">this token needs role 'supabase_admin' or 'service_role'</param>
         /// <param name="options"></param>
+        /// <param name="uid"></param>
+        /// <param name="shouldSoftDelete">If true, then the user will be soft-deleted. Defaults to false.</param>
         /// <returns></returns>
-        Task<bool> DeleteUser(string uid, string serviceRoleToken, StatelessClientOptions options);
+        Task<bool> DeleteUser(string serviceRoleToken, StatelessClientOptions options, string uid, bool shouldSoftDelete = false);
 
         /// <summary>
         /// Logs in an existing user via a third-party provider.

--- a/Gotrue/StatelessClient.cs
+++ b/Gotrue/StatelessClient.cs
@@ -314,9 +314,9 @@ namespace Supabase.Gotrue
 		}
 
 		/// <inheritdoc />
-		public async Task<bool> DeleteUser(string uid, string serviceRoleToken, StatelessClientOptions options)
+		public async Task<bool> DeleteUser(string serviceRoleToken, StatelessClientOptions options, string uid, bool shouldSoftDelete = false)
 		{
-			var result = await GetApi(options).DeleteUser(uid, serviceRoleToken);
+			var result = await GetApi(options).DeleteUser(serviceRoleToken, uid, shouldSoftDelete);
 			result.ResponseMessage?.EnsureSuccessStatusCode();
 			return true;
 		}

--- a/GotrueTests/StatelessClientTests.cs
+++ b/GotrueTests/StatelessClientTests.cs
@@ -259,7 +259,7 @@ namespace GotrueTests
 			var uid = session.User.Id;
 
 			var serviceRoleKey = GenerateServiceRoleToken();
-			var result = await _client.DeleteUser(uid, serviceRoleKey, Options);
+			var result = await _client.DeleteUser(serviceRoleKey, Options, uid);
 
 			Assert.IsTrue(result);
 		}


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR adds support for soft-deleting users via the Admin Auth API by introducing an optional `shouldSoftDelete` parameter to the `DeleteUser` method. No breaking changes were made.

More about user deletion can be seen in the [JavaScript docs](https://supabase.com/docs/reference/javascript/auth-admin-deleteuser)

## What is the current behavior?

Users cannot be soft deleted.

## What is the new behavior?

Soft deletion is possible by setting an optional parameter to true.
