### PR TITLE
Fix token refresh logic

### DIFF
--- a/Gotrue/Client.cs
+++ b/Gotrue/Client.cs
@@ -530,7 +530,6 @@ namespace Supabase.Gotrue
 				TokenType = "bearer",
 				ExpiresIn = expiresIn,
 				User = await _api.GetUser(accessToken),
-				CreatedAt = iat,
 			};
 
 			NotifyAuthStateChange(SignedIn);
@@ -573,8 +572,6 @@ namespace Supabase.Gotrue
 
 			var user = await _api.GetUser(accessToken);
 
-			var payload = new JwtSecurityTokenHandler().ReadJwtToken(accessToken).Payload;
-
 			var session = new Session
 			{
 				AccessToken = accessToken,
@@ -582,7 +579,6 @@ namespace Supabase.Gotrue
 				RefreshToken = refreshToken,
 				TokenType = tokenType,
 				User = user,
-				CreatedAt = payload.IssuedAt,
 			};
 
 			if (storeSession)
@@ -791,8 +787,6 @@ namespace Supabase.Gotrue
 
 			if (result == null || string.IsNullOrEmpty(result.AccessToken))
 				throw new GotrueException("Could not verify MFA.", MfaChallengeUnverified);
-
-			var payload = new JwtSecurityTokenHandler().ReadJwtToken(result.AccessToken).Payload;
 			
 			var session = new Session
 			{
@@ -800,8 +794,7 @@ namespace Supabase.Gotrue
 				RefreshToken = result.RefreshToken,
 				TokenType = "bearer",
 				ExpiresIn = result.ExpiresIn,
-				User = result.User,
-				CreatedAt = payload.IssuedAt,
+				User = result.User
 			};
 
 			UpdateSession(session);
@@ -838,8 +831,7 @@ namespace Supabase.Gotrue
 
 			if (result == null || string.IsNullOrEmpty(result.AccessToken))
 				throw new GotrueException("Could not verify MFA.", MfaChallengeUnverified);
-
-			var payload = new JwtSecurityTokenHandler().ReadJwtToken(result.AccessToken).Payload;
+			
 			var session = new Session
 			{
 				AccessToken = result.AccessToken,
@@ -847,7 +839,6 @@ namespace Supabase.Gotrue
 				TokenType = "bearer",
 				ExpiresIn = result.ExpiresIn,
 				User = result.User,
-				CreatedAt = payload.IssuedAt,
 			};
 
 			UpdateSession(session);

--- a/Gotrue/Session.cs
+++ b/Gotrue/Session.cs
@@ -17,7 +17,7 @@ namespace Supabase.Gotrue
 		public string? AccessToken { get; set; }
 
 		/// <summary>
-		/// The number of seconds until the token expires (since it was issued). Returned when a login is confirmed.
+		/// The number of seconds until the access token expires (since it was issued). Returned when a login is confirmed.
 		/// </summary>
 		[JsonProperty("expires_in")]
 		public long ExpiresIn { get; set; }
@@ -49,17 +49,5 @@ namespace Supabase.Gotrue
 
 		[JsonProperty("created_at")]
 		public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
-
-		/// <summary>
-		/// The expiration date of this session, in UTC time.
-		/// </summary>
-		/// <returns></returns>
-		public DateTime ExpiresAt() => new DateTimeOffset(CreatedAt).AddSeconds(ExpiresIn).ToUniversalTime().DateTime;
-
-		/// <summary>
-		/// Returns true if the session has expired
-		/// </summary>
-		/// <returns></returns>
-		public bool Expired() => ExpiresAt() < DateTime.UtcNow;
 	}
 }

--- a/GotrueTests/AnonKeyClientTests.cs
+++ b/GotrueTests/AnonKeyClientTests.cs
@@ -481,15 +481,5 @@ namespace GotrueTests
 			// As this is being forced to regenerate, the original should be different than the cached.
 			AreNotEqual(refreshToken, _client.CurrentSession.RefreshToken);
 		}
-
-		[TestMethod("Session: `ExpiresAt` is Calculated Correctly.")]
-		public async Task SessionCalculatesExpiresAtCorrectly()
-		{
-			var email = $"{RandomString(12)}@supabase.io";
-			var session = await _client.SignUp(email, PASSWORD);
-
-			IsFalse(session.Expired());
-			AreEqual(session.ExpiresAt().Ticks, session.CreatedAt.ToUniversalTime().AddSeconds(session.ExpiresIn).Ticks);
-		}
 	}
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

- Token refresh logic rejects refreshes if the access token is expired. 
- In many (most?) use cases the token will never refresh.

#108 #112 #106 #109 

## What is the new behavior?

Tokens refresh correctly.

## Additional context

We have been wrongly assuming that `Session.ExpiresIn` represented the users Supabase session expiry time. And that we should invalidate the users session when this time expired. 
The `Session.ExpiresIn` property actually represents the entire lifetime (in seconds) of the access token (if you set a JWT expiry in Supabase of 3600 then `ExpiresIn` should always be 3600).
We should not be concerned with "ending sessions" in this library. That is handled by Supabase invalidating the refresh tokens. So I have removed all of the `Expired()` checks.

The `SetSession` method in `Client.cs`  was also setting an incorrect value for `ExpiresIn`, using `payload.Expiration` which is the timestamp for when the token expires, not the expected `expires_in` time. So I  have calculated that as the payloads `(exp - iat)`. 

After these changes the `ExpiresAt()` and `Expired()` methods in `Session.cs` are unused so I have removed them as well as the `AnonKeyClientTests.cs` `SessionCalculatesExpiresAtTimeCorrectly()` method. 