### PR TITLE
Update GoTrue Admin API to align with current Supabase endpoints

### DIFF
--- a/Gotrue/AdminClient.cs
+++ b/Gotrue/AdminClient.cs
@@ -69,9 +69,9 @@ namespace Supabase.Gotrue
 		}
 
 		/// <inheritdoc />
-		public async Task<bool> DeleteUser(string uid)
+		public async Task<bool> DeleteUser(string uid, bool shouldSoftDelete = false)
 		{
-			var result = await _api.DeleteUser(uid, _serviceKey);
+			var result = await _api.DeleteUser(uid, _serviceKey, shouldSoftDelete);
 			result.ResponseMessage?.EnsureSuccessStatusCode();
 			return true;
 		}

--- a/Gotrue/Interfaces/IGotrueAdminClient.cs
+++ b/Gotrue/Interfaces/IGotrueAdminClient.cs
@@ -35,7 +35,7 @@ namespace Supabase.Gotrue.Interfaces
 		/// Creates a user using the admin key (not the anonymous key).
 		/// Used in trusted server environments, not client apps.
 		/// </summary>
-		Task<bool> DeleteUser(string uid);
+		Task<bool> DeleteUser(string uid, bool shouldSoftDelete = false);
 
 		/// <summary>
 		/// Gets a user from a user's JWT. This is using the GoTrue server to validate a user's JWT.

--- a/Gotrue/Interfaces/IGotrueApi.cs
+++ b/Gotrue/Interfaces/IGotrueApi.cs
@@ -14,7 +14,7 @@ namespace Supabase.Gotrue.Interfaces
 		where TSession : Session
 	{
 		Task<TUser?> CreateUser(string jwt, AdminUserAttributes? attributes = null);
-		Task<BaseResponse> DeleteUser(string uid, string jwt);
+		Task<BaseResponse> DeleteUser(string uid, string jwt, bool shouldSoftDelete = false);
 		Task<TUser?> GetUser(string jwt);
 		Task<TUser?> GetUserById(string jwt, string userId);
 		Task<BaseResponse> InviteUserByEmail(string email, string jwt, InviteUserByEmailOptions? options = null);

--- a/Gotrue/Interfaces/IGotrueStatelessClient.cs
+++ b/Gotrue/Interfaces/IGotrueStatelessClient.cs
@@ -43,8 +43,9 @@ namespace Supabase.Gotrue.Interfaces
         /// <param name="uid"></param>
         /// <param name="serviceRoleToken">this token needs role 'supabase_admin' or 'service_role'</param>
         /// <param name="options"></param>
+        /// <param name="shouldSoftDelete">If true, then the user will be soft-deleted from the auth schema. Soft deletion allows user identification from the hashed user ID but is not reversible. Defaults to false for backward compatibility.</param>
         /// <returns></returns>
-        Task<bool> DeleteUser(string uid, string serviceRoleToken, StatelessClientOptions options);
+        Task<bool> DeleteUser(string uid, string serviceRoleToken, StatelessClientOptions options, bool shouldSoftDelete = false);
 
         /// <summary>
         /// Logs in an existing user via a third-party provider.

--- a/Gotrue/StatelessClient.cs
+++ b/Gotrue/StatelessClient.cs
@@ -314,9 +314,9 @@ namespace Supabase.Gotrue
 		}
 
 		/// <inheritdoc />
-		public async Task<bool> DeleteUser(string uid, string serviceRoleToken, StatelessClientOptions options)
+		public async Task<bool> DeleteUser(string uid, string serviceRoleToken, StatelessClientOptions options, bool shouldSoftDelete = false)
 		{
-			var result = await GetApi(options).DeleteUser(uid, serviceRoleToken);
+			var result = await GetApi(options).DeleteUser(uid, serviceRoleToken, shouldSoftDelete);
 			result.ResponseMessage?.EnsureSuccessStatusCode();
 			return true;
 		}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Updated C# package to support new API structure for admin commands

## What is the current behavior?

- Admin operations fail if using the new JWT keys
- No ability to soft delete users

## What is the new behavior?

- Header "apiKey" is set for functions requiring "serviceRoleToken"
- Added optional parameter "shouldSoftDelete" against DeleteUser

## Additional context

N/A