### PR TITLE
feat: LinkIdentity using idToken

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,10 +10,10 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.x
 

--- a/.github/workflows/build-documentation.yaml
+++ b/.github/workflows/build-documentation.yaml
@@ -10,12 +10,12 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.x
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,10 @@ jobs:
     name: build, pack & publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.x
 

--- a/Gotrue/Api.cs
+++ b/Gotrue/Api.cs
@@ -598,6 +598,31 @@ namespace Supabase.Gotrue
 		}
 
 		/// <inheritdoc />
+		public Task<Session?> LinkIdentityWithIdToken(string token, Provider provider, string idToken, string? accessToken = null, string? nonce = null, string? captchaToken = null)
+		{
+			if (provider != Provider.Google && provider != Provider.Apple && provider != Provider.Azure && provider != Provider.Facebook)
+				throw new GotrueException($"Provider must be `Google`, `Apple`, `Azure`, or `Facebook` not {provider}");
+
+			var body = new Dictionary<string, object?>
+			{
+				{ "provider", Core.Helpers.GetMappedToAttr(provider).Mapping },
+				{ "id_token", idToken },
+				{ "link_identity", true },
+			};
+
+			if (!string.IsNullOrEmpty(accessToken))
+				body.Add("access_token", accessToken);
+
+			if (!string.IsNullOrEmpty(nonce))
+				body.Add("nonce", nonce);
+
+			if (!string.IsNullOrEmpty(captchaToken))
+				body.Add("gotrue_meta_security", new Dictionary<string, object?> { { "captcha_token", captchaToken } });
+
+			return Helpers.MakeRequest<Session>(HttpMethod.Post, $"{Url}/token?grant_type=id_token", body, CreateAuthedRequestHeaders(token));
+		}
+
+		/// <inheritdoc />
 		public async Task<bool> UnlinkIdentity(string token, UserIdentity userIdentity)
 		{
 			var result = await Helpers.MakeRequest(HttpMethod.Delete, $"{Url}/user/identities/${userIdentity.IdentityId}", null, CreateAuthedRequestHeaders(token));

--- a/Gotrue/Api.cs
+++ b/Gotrue/Api.cs
@@ -593,7 +593,27 @@ namespace Supabase.Gotrue
 		public async Task<ProviderAuthState> LinkIdentity(string token, Provider provider, SignInOptions options)
 		{
 			var state = Helpers.GetUrlForProvider($"{Url}/user/identities/authorize", provider, options);
-			await Helpers.MakeRequest(HttpMethod.Get, state.Uri.ToString(), null, CreateAuthedRequestHeaders(token));
+
+			// Ask the server to return the provider URL in the response body instead of issuing
+			// a 302 redirect. Without this, HttpClient follows the redirect chain and drops the
+			// Authorization/apikey headers on cross-domain hops, causing Kong to reject the
+			// request with "No API key found in request".
+			var builder = new UriBuilder(state.Uri);
+			var query = HttpUtility.ParseQueryString(builder.Query);
+			query["skip_http_redirect"] = "true";
+			builder.Query = query.ToString();
+
+			var response = await Helpers.MakeRequest(HttpMethod.Get, builder.Uri.ToString(), null, CreateAuthedRequestHeaders(token));
+
+			if (!string.IsNullOrEmpty(response?.Content))
+			{
+				var payload = JsonConvert.DeserializeObject<Dictionary<string, string>>(response!.Content!);
+				if (payload != null && payload.TryGetValue("url", out var url) && !string.IsNullOrEmpty(url))
+				{
+					state.Uri = new Uri(url);
+				}
+			}
+
 			return state;
 		}
 

--- a/Gotrue/Api.cs
+++ b/Gotrue/Api.cs
@@ -645,7 +645,7 @@ namespace Supabase.Gotrue
 		/// <inheritdoc />
 		public async Task<bool> UnlinkIdentity(string token, UserIdentity userIdentity)
 		{
-			var result = await Helpers.MakeRequest(HttpMethod.Delete, $"{Url}/user/identities/${userIdentity.IdentityId}", null, CreateAuthedRequestHeaders(token));
+			var result = await Helpers.MakeRequest(HttpMethod.Delete, $"{Url}/user/identities/{userIdentity.IdentityId}", null, CreateAuthedRequestHeaders(token));
 			return result.ResponseMessage is { IsSuccessStatusCode: true };
 		}
 

--- a/Gotrue/Client.cs
+++ b/Gotrue/Client.cs
@@ -411,6 +411,27 @@ namespace Supabase.Gotrue
 		}
 
 		/// <inheritdoc />
+		public async Task<Session?> LinkIdentity(Provider provider, string idToken, string? accessToken = null,
+			string? nonce = null, string? captchaToken = null)
+		{
+			if (!Online)
+				throw new GotrueException("Only supported when online", Offline);
+
+			if (CurrentSession == null || CurrentUser == null)
+				throw new GotrueException("A valid session is required.", NoSessionFound);
+
+			var result = await _api.LinkIdentityWithIdToken(CurrentSession.AccessToken!, provider, idToken, accessToken, nonce, captchaToken);
+
+			if (result?.AccessToken != null)
+			{
+				UpdateSession(result);
+				NotifyAuthStateChange(SignedIn);
+			}
+
+			return result;
+		}
+
+		/// <inheritdoc />
 		public Task<bool> UnlinkIdentity(UserIdentity userIdentity)
 		{
 			if (!Online)

--- a/Gotrue/Interfaces/IGotrueApi.cs
+++ b/Gotrue/Interfaces/IGotrueApi.cs
@@ -64,6 +64,21 @@ namespace Supabase.Gotrue.Interfaces
 		Task<ProviderAuthState> LinkIdentity(string token, Provider provider, SignInOptions options);
 
 		/// <summary>
+		/// Links an OIDC identity to an existing user using a native ID token.
+		///
+		/// This method does not require the PKCE flow and supports Google, Apple, Azure, and Facebook providers.
+		/// The request is authenticated with the user's current access token.
+		/// </summary>
+		/// <param name="token">User's current access token (Bearer JWT)</param>
+		/// <param name="provider">A supported provider (Google, Apple, Azure, Facebook)</param>
+		/// <param name="idToken">OIDC ID token issued by the specified provider</param>
+		/// <param name="accessToken">If the ID token contains an `at_hash` claim, then the hash of this value is compared to the value in the ID token.</param>
+		/// <param name="nonce">If the ID token contains a `nonce` claim, then the hash of this value is compared to the value in the ID token.</param>
+		/// <param name="captchaToken">Verification token received when the user completes the captcha on the site.</param>
+		/// <returns></returns>
+		Task<TSession?> LinkIdentityWithIdToken(string token, Provider provider, string idToken, string? accessToken = null, string? nonce = null, string? captchaToken = null);
+
+		/// <summary>
 		/// Unlinks an identity from a user by deleting it. The user will no longer be able to sign in with that identity once it's unlinked.
 		/// </summary>
 		/// <param name="token">User's token</param>

--- a/Gotrue/Interfaces/IGotrueClient.cs
+++ b/Gotrue/Interfaces/IGotrueClient.cs
@@ -407,6 +407,21 @@ namespace Supabase.Gotrue.Interfaces
 		Task<ProviderAuthState> LinkIdentity(Provider provider, SignInOptions options);
 
 		/// <summary>
+		/// Links an OIDC identity to an existing user using a native ID token issued by a supported provider.
+		///
+		/// This method does not require the PKCE flow.
+		/// The identity is linked to the currently authenticated user.
+		/// Supported providers: Google, Apple, Azure, Facebook.
+		/// </summary>
+		/// <param name="provider">A supported provider (Google, Apple, Azure, Facebook)</param>
+		/// <param name="idToken">OIDC ID token issued by the specified provider. The `iss` claim in the ID token must match the supplied provider.</param>
+		/// <param name="accessToken">If the ID token contains an `at_hash` claim, then the hash of this value is compared to the value in the ID token.</param>
+		/// <param name="nonce">If the ID token contains a `nonce` claim, then the hash of this value is compared to the value in the ID token.</param>
+		/// <param name="captchaToken">Verification token received when the user completes the captcha on the site.</param>
+		/// <returns>A new session reflecting the linked identity, or null.</returns>
+		Task<TSession?> LinkIdentity(Provider provider, string idToken, string? accessToken = null, string? nonce = null, string? captchaToken = null);
+
+		/// <summary>
 		/// Unlinks an identity from a user by deleting it. The user will no longer be able to sign in with that identity once it's unlinked.
 		/// </summary>
 		/// <param name="userIdentity">Identity to be unlinked</param>


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR enables manual identity linking using native idTokens instead of only the PKCE flow. It also fixes an issue where the apiKey was lost during a redirect in the PKCE linking flow, causing an error. It now follows the logic in the JS library to avoid a redirect. There was also a minor typo in the unlinking flow's URL builder. Finally, the GitHub Actions tags were bumped due to the versions going EOL.

## What is the current behavior?

Currently, there is no function to link with an idToken while the JS library supports this behavior.

## What is the new behavior?

You can now manually link identities using idToken in addition to PKCE.