### PR TITLE
fix: classify refresh token rejections from current gotrue

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,8 +23,16 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release --no-restore
 
-      - name: Initialize Testing Stack
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Initialize Legacy Testing Stack
         run: docker compose up -d
+
+      - name: Initialize Supabase CLI Stack
+        run: supabase start
 
       - name: Test
         run: dotnet test --no-restore

--- a/.gitignore
+++ b/.gitignore
@@ -403,3 +403,6 @@ ASALocalRun/
 
 # Local History for Visual Studio
 .localhistory/
+# Supabase CLI local state
+supabase/.temp/
+supabase/.branches/

--- a/Gotrue/Exceptions/FailureReason.cs
+++ b/Gotrue/Exceptions/FailureReason.cs
@@ -105,7 +105,12 @@ namespace Supabase.Gotrue.Exceptions
 			{
 				400 when gte.Content.Contains("Invalid login") => UserBadLogin,
 				400 when gte.Content.Contains("Email not confirmed") => UserEmailNotConfirmed,
+				// Gotrue rejects refresh tokens on two paths: malformed tokens fail format validation
+				// ("Refresh token is not valid", validation_failed) before lookup, while well-formed
+				// unknown tokens return "Invalid Refresh Token" (refresh_token_not_found).
 				400 when gte.Content.Contains("Invalid Refresh Token") => InvalidRefreshToken,
+				400 when gte.Content.Contains("refresh_token_not_found") => InvalidRefreshToken,
+				400 when gte.Content.Contains("Refresh token is not valid") => InvalidRefreshToken,
 				400 when gte.Content.Contains("Phone") => UserBadPhoneNumber,
 				400 when gte.Content.Contains("phone") => UserBadPhoneNumber,
 				400 when gte.Content.Contains("Email") => UserBadEmailAddress,

--- a/Gotrue/Interfaces/IGotrueClient.cs
+++ b/Gotrue/Interfaces/IGotrueClient.cs
@@ -465,6 +465,20 @@ namespace Supabase.Gotrue.Interfaces
 		/// <returns></returns>
 		public Task RefreshToken();
 
+		/// <summary>
+		/// Refreshes a Token using the provided access and refresh tokens, replacing the
+		/// current session with the result. Useful when resuming from a persisted session:
+		/// the refresh token is one-time-use and never expires server-side, so it can mint a
+		/// new session even if the access token has long expired.
+		///
+		/// If the server rejects the refresh token, the current session is destroyed and a
+		/// <see cref="Exceptions.GotrueException"/> with reason
+		/// <see cref="Exceptions.FailureHint.Reason.InvalidRefreshToken"/> is thrown.
+		/// </summary>
+		/// <param name="accessToken">The access token to send as the bearer authorization.</param>
+		/// <param name="refreshToken">The refresh token to exchange for a new session.</param>
+		public Task RefreshToken(string accessToken, string refreshToken);
+
 		#region MFA
 		/// <summary>
 		/// Starts the enrollment process for a new Multi-Factor Authentication (MFA)

--- a/GotrueTests/AnonKeyClientFailureTests.cs
+++ b/GotrueTests/AnonKeyClientFailureTests.cs
@@ -112,47 +112,6 @@ namespace GotrueTests
 			AreEqual(1, _stateChanges.Count);
 		}
 
-		[TestMethod("Client: Bogus refresh token")]
-		public async Task ClientTriggersTokenRefreshedEvent()
-		{
-			var email = $"{RandomString(12)}@supabase.io";
-			var user = await _client.SignUp(email, PASSWORD);
-			IsNotNull(user);
-
-			_client.CurrentSession.RefreshToken = "bogus token";
-
-			var x = await ThrowsExceptionAsync<GotrueException>(async () =>
-			{
-				await _client.RefreshSession();
-			});
-			
-			AreEqual(InvalidRefreshToken, x.Reason);
-			IsNull(_client.CurrentSession);
-		}
-
-		[TestMethod("Client: expired token")]
-		public async Task ExpiredTokenTest()
-		{
-			var email = $"{RandomString(12)}@supabase.io";
-			var emailSession = await _client.SignUp(email, PASSWORD);
-
-			IsNotNull(emailSession.AccessToken);
-			IsNotNull(emailSession.RefreshToken);
-			IsNotNull(emailSession.User);
-
-			// Set CreatedAt to an old date - this should NOT prevent refresh from working
-			// Session "expiration" based on CreatedAt is about access token lifetime, not refresh token validity
-			_client.CurrentSession.CreatedAt = DateTime.UtcNow.AddDays(-10);
-
-			// Refresh should still succeed with a valid refresh token
-			await _client.RefreshSession();
-
-			IsNotNull(_client.CurrentSession);
-			IsNotNull(_client.CurrentSession.AccessToken);
-			IsNotNull(_client.CurrentSession.RefreshToken);
-			IsNotNull(_client.CurrentSession.User);
-		}
-
 		[TestMethod("Client: Send Reset Password Email for unknown email")]
 		public async Task ClientSendsResetPasswordForEmail()
 		{

--- a/GotrueTests/AnonKeyClientTests.cs
+++ b/GotrueTests/AnonKeyClientTests.cs
@@ -123,38 +123,6 @@ namespace GotrueTests
 			AreEqual("Testing", session.User.UserMetadata["firstName"]);
 		}
 
-		[TestMethod("Client: Triggers Token Refreshed Event")]
-		public async Task ClientTriggersTokenRefreshedEvent()
-		{
-			var tsc = new TaskCompletionSource<string>();
-
-			var email = $"{RandomString(12)}@supabase.io";
-
-			IsTrue(AuthStateIsEmpty());
-
-			var session = await _client.SignUp(email, PASSWORD);
-
-			VerifyGoodSession(session);
-
-			_client.AddStateChangedListener((_, args) =>
-			{
-				if (args == TokenRefreshed)
-				{
-					tsc.SetResult(_client.CurrentSession.AccessToken);
-				}
-			});
-
-			_stateChanges.Clear();
-
-			await _client.RefreshSession();
-			Contains(_stateChanges, TokenRefreshed);
-			AreEqual(_client.CurrentSession, _persistence.SavedSession);
-
-			var newToken = await tsc.Task;
-			IsNotNull(newToken);
-			AreNotEqual(session.RefreshToken, _client.CurrentSession.RefreshToken);
-		}
-
 		[TestMethod("Client: Signs In User (Email, Phone, Refresh token)")]
 		public async Task ClientSignsIn()
 		{

--- a/GotrueTests/GotrueTests.csproj
+++ b/GotrueTests/GotrueTests.csproj
@@ -11,10 +11,12 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="[7.2.2]" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.5.1" />
+    <PackageReference Include="WireMock.Net" Version="2.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GotrueTests/Support/MockGotrueServer.cs
+++ b/GotrueTests/Support/MockGotrueServer.cs
@@ -1,13 +1,12 @@
 using System;
 using System.Linq;
 using System.Net.Http;
+using FluentAssertions;
 using Newtonsoft.Json.Linq;
 using WireMock;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using WireMock.Server;
-using static Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
-using static Microsoft.VisualStudio.TestTools.UnitTesting.StringAssert;
 
 namespace GotrueTests.Support
 {
@@ -29,8 +28,8 @@ namespace GotrueTests.Support
 
 		internal ReceivedRequest VerifySingleReceivedRequest()
 		{
-			AreEqual(1, server.LogEntries.Count, "expected the SDK to emit exactly one request");
-			return new ReceivedRequest(server.LogEntries.Single().RequestMessage);
+			var entry = server.LogEntries.Should().ContainSingle("the SDK should emit exactly one request").Which;
+			return new ReceivedRequest(entry.RequestMessage);
 		}
 
 		public void Dispose() => server.Stop();
@@ -47,44 +46,39 @@ namespace GotrueTests.Support
 
 		internal ReceivedRequest WithPath(string path)
 		{
-			AreEqual(path, request.Path);
+			request.Path.Should().Be(path);
 			return this;
 		}
-
 
 		internal ReceivedRequest WithMethod(HttpMethod method)
 		{
-			AreEqual(method.ToString(), request.Method);
+			request.Method.Should().Be(method.ToString());
 			return this;
 		}
 
-
 		internal ReceivedRequest WithQueryParam(string name, string expected)
 		{
-			IsTrue(request.Query != null && request.Query.ContainsKey(name), $"missing query parameter '{name}'");
-			AreEqual(expected, request.Query[name].Single());
+			request.Query.Should().ContainKey(name).WhoseValue.Single().Should().Be(expected);
 			return this;
 		}
 
 		internal ReceivedRequest WithHeader(string name, string expected)
 		{
-			IsTrue(request.Headers != null && request.Headers.ContainsKey(name), $"missing header '{name}'");
-			AreEqual(expected, request.Headers[name].Single());
+			request.Headers.Should().ContainKey(name).WhoseValue.Single().Should().Be(expected);
 			return this;
 		}
 
 		internal ReceivedRequest WithJsonContentType()
 		{
-			IsTrue(request.Headers != null && request.Headers.ContainsKey("Content-Type"), "missing Content-Type header");
-			StartsWith(request.Headers["Content-Type"].Single(), "application/json");
+			request.Headers.Should().ContainKey("Content-Type").WhoseValue.Single().Should().StartWith("application/json");
 			return this;
 		}
 
 		internal void WithExactJsonBody(string field, string expected)
 		{
-			IsNotNull(request.Body, "request has no body");
+			request.Body.Should().NotBeNull("the request should have a body");
 			var body = JObject.Parse(request.Body);
-			AreEqual(expected, (string)body[field]);
+			((string)body[field]).Should().Be(expected);
 		}
 	}
 }

--- a/GotrueTests/Support/MockGotrueServer.cs
+++ b/GotrueTests/Support/MockGotrueServer.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Linq;
+using System.Net.Http;
+using Newtonsoft.Json.Linq;
+using WireMock;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+using static Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+using static Microsoft.VisualStudio.TestTools.UnitTesting.StringAssert;
+
+namespace GotrueTests.Support
+{
+	internal sealed class MockGotrueServer : IDisposable
+	{
+		internal const string ApiKey = "test-api-key";
+
+		private readonly WireMockServer server = WireMockServer.Start();
+
+		internal string Url => server.Url!;
+
+		internal void RespondsTo(string path, int statusCode, string jsonBody) =>
+			server
+				.Given(Request.Create().WithPath(path))
+				.RespondWith(Response.Create()
+					.WithStatusCode(statusCode)
+					.WithHeader("Content-Type", "application/json")
+					.WithBody(jsonBody));
+
+		internal ReceivedRequest VerifySingleReceivedRequest()
+		{
+			AreEqual(1, server.LogEntries.Count, "expected the SDK to emit exactly one request");
+			return new ReceivedRequest(server.LogEntries.Single().RequestMessage);
+		}
+
+		public void Dispose() => server.Stop();
+	}
+
+	/// <summary>
+	/// Fluent assertions over a request the SDK sent to the <see cref="MockGotrueServer"/>.
+	/// </summary>
+	internal sealed class ReceivedRequest
+	{
+		private readonly IRequestMessage request;
+
+		internal ReceivedRequest(IRequestMessage request) => this.request = request;
+
+		internal ReceivedRequest WithPath(string path)
+		{
+			AreEqual(path, request.Path);
+			return this;
+		}
+
+
+		internal ReceivedRequest WithMethod(HttpMethod method)
+		{
+			AreEqual(method.ToString(), request.Method);
+			return this;
+		}
+
+
+		internal ReceivedRequest WithQueryParam(string name, string expected)
+		{
+			IsTrue(request.Query != null && request.Query.ContainsKey(name), $"missing query parameter '{name}'");
+			AreEqual(expected, request.Query[name].Single());
+			return this;
+		}
+
+		internal ReceivedRequest WithHeader(string name, string expected)
+		{
+			IsTrue(request.Headers != null && request.Headers.ContainsKey(name), $"missing header '{name}'");
+			AreEqual(expected, request.Headers[name].Single());
+			return this;
+		}
+
+		internal ReceivedRequest WithJsonContentType()
+		{
+			IsTrue(request.Headers != null && request.Headers.ContainsKey("Content-Type"), "missing Content-Type header");
+			StartsWith(request.Headers["Content-Type"].Single(), "application/json");
+			return this;
+		}
+
+		internal void WithExactJsonBody(string field, string expected)
+		{
+			IsNotNull(request.Body, "request has no body");
+			var body = JObject.Parse(request.Body);
+			AreEqual(expected, (string)body[field]);
+		}
+	}
+}

--- a/GotrueTests/Support/TestClients.cs
+++ b/GotrueTests/Support/TestClients.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using Supabase.Gotrue;
+using Supabase.Gotrue.Interfaces;
+
+namespace GotrueTests.Support
+{
+	/// <summary>
+	/// One place to build a Gotrue client per test tier: contract tests get a client pointed
+	/// at a <see cref="MockGotrueServer"/>, behavior tests get one pointed at the local
+	/// Supabase CLI stack (overridable with SUPABASE_CLI_AUTH_URL / SUPABASE_CLI_ANON_KEY).
+	/// </summary>
+	internal static class TestClients
+	{
+		private static readonly string CliAuthUrl =
+			Environment.GetEnvironmentVariable("SUPABASE_CLI_AUTH_URL") ?? "http://127.0.0.1:54321/auth/v1";
+
+		private static readonly string CliAnonKey =
+			Environment.GetEnvironmentVariable("SUPABASE_CLI_ANON_KEY") ??
+			"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0";
+
+		internal static IGotrueClient<User, Session> AgainstCliStack() =>
+			Build(CliAuthUrl, CliAnonKey, autoRefreshToken: true, allowUnconfirmedUserSessions: true);
+
+		internal static IGotrueClient<User, Session> Against(MockGotrueServer server) =>
+			Build(server.Url, MockGotrueServer.ApiKey, autoRefreshToken: false, allowUnconfirmedUserSessions: false);
+
+		private static IGotrueClient<User, Session> Build(string url, string apiKey, bool autoRefreshToken, bool allowUnconfirmedUserSessions) =>
+			new Client(new ClientOptions
+			{
+				Url = url,
+				AutoRefreshToken = autoRefreshToken,
+				AllowUnconfirmedUserSessions = allowUnconfirmedUserSessions,
+				Headers = new Dictionary<string, string> { { "apikey", apiKey } }
+			});
+	}
+}

--- a/GotrueTests/TokenRefresh/RefreshBehaviorTests.cs
+++ b/GotrueTests/TokenRefresh/RefreshBehaviorTests.cs
@@ -48,20 +48,19 @@ public class RefreshBehaviorTests
 		await VerifyRotatedSession(signUp, refreshed);
 	}
 
-	[TestMethod("Refreshing with a malformed refresh token throws InvalidRefreshToken and destroys the session")]
-	public async Task RefreshFailsWithMalformedToken()
+	[DataTestMethod("Refreshing with a rejected refresh token throws InvalidRefreshToken and destroys the session")]
+	[DataRow("bogus-token", DisplayName = "Malformed token")]
+	[DataRow("abcdef012345", DisplayName = "Well-formed unknown token")]
+	public async Task RefreshFailsWithRejectedToken(string rejectedToken)
 	{
 		await SignUpNewUser();
-		client.CurrentSession!.RefreshToken = "bogus-token";
-		await VerifyRefreshFailsAndDestroysSession();
-	}
+		client.CurrentSession!.RefreshToken = rejectedToken;
 
-	[TestMethod("Refreshing with a well-formed token the server does not know throws InvalidRefreshToken and destroys the session")]
-	public async Task RefreshFailsWithUnknownToken()
-	{
-		await SignUpNewUser();
-		client.CurrentSession!.RefreshToken = "abcdef012345";
-		await VerifyRefreshFailsAndDestroysSession();
+		Func<Task> refresh = () => client.RefreshSession();
+		var exception = await refresh.Should().ThrowAsync<GotrueException>();
+
+		exception.Which.Reason.Should().Be(InvalidRefreshToken);
+		client.CurrentSession.Should().BeNull();
 	}
 
 	private sealed record SignUpResult(Session Session, string UserId);
@@ -72,14 +71,6 @@ public class RefreshBehaviorTests
 		session.Should().NotBeNull();
 		session!.User?.Id.Should().NotBeNullOrEmpty();
 		return new SignUpResult(session, session.User!.Id!);
-	}
-
-	private async Task VerifyRefreshFailsAndDestroysSession()
-	{
-		var refresh = () => client.RefreshSession();
-		var exception = await refresh.Should().ThrowAsync<GotrueException>();
-		exception.Which.Reason.Should().Be(InvalidRefreshToken);
-		client.CurrentSession.Should().BeNull();
 	}
 
 	private void ExpireCurrentSession()

--- a/GotrueTests/TokenRefresh/RefreshBehaviorTests.cs
+++ b/GotrueTests/TokenRefresh/RefreshBehaviorTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GotrueTests.Support;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Supabase.Gotrue;
+using Supabase.Gotrue.Exceptions;
+using Supabase.Gotrue.Interfaces;
+using static GotrueTests.TestUtils;
+using static Supabase.Gotrue.Constants.AuthState;
+using static Supabase.Gotrue.Exceptions.FailureHint.Reason;
+
+namespace GotrueTests.TokenRefresh;
+
+[TestClass]
+[TestCategory("Behavior")]
+public class RefreshBehaviorTests
+{
+	private readonly List<Constants.AuthState> stateChanges = [];
+	private IGotrueClient<User, Session> client;
+	private TestSessionPersistence persistence;
+
+	[TestInitialize]
+	public void TestInitializer()
+	{
+		persistence = new TestSessionPersistence();
+		client = TestClients.AgainstCliStack();
+		client.SetPersistence(persistence);
+		client.AddDebugListener(LogDebug);
+		client.AddStateChangedListener((_, state) => stateChanges.Add(state));
+	}
+
+	[TestMethod("Refreshing a session rotates the refresh token and the server accepts the new access token")]
+	public async Task RefreshRotatesToken()
+	{
+		var signUp = await SignUpNewUser();
+		var refreshed = await client.RefreshSession();
+		await VerifyRotatedSession(signUp, refreshed);
+	}
+
+	[TestMethod("Refreshing an expired session succeeds")]
+	public async Task RefreshSucceedsWhenExpired()
+	{
+		var signUp = await SignUpNewUser();
+		ExpireCurrentSession();
+		var refreshed = await client.RefreshSession();
+		await VerifyRotatedSession(signUp, refreshed);
+	}
+
+	[TestMethod("Refreshing with a malformed refresh token throws InvalidRefreshToken and destroys the session")]
+	public async Task RefreshFailsWithMalformedToken()
+	{
+		await SignUpNewUser();
+		client.CurrentSession!.RefreshToken = "bogus-token";
+		await VerifyRefreshFailsAndDestroysSession();
+	}
+
+	[TestMethod("Refreshing with a well-formed token the server does not know throws InvalidRefreshToken and destroys the session")]
+	public async Task RefreshFailsWithUnknownToken()
+	{
+		await SignUpNewUser();
+		client.CurrentSession!.RefreshToken = "abcdef012345";
+		await VerifyRefreshFailsAndDestroysSession();
+	}
+
+	private sealed record SignUpResult(Session Session, string UserId);
+
+	private async Task<SignUpResult> SignUpNewUser()
+	{
+		var session = await client.SignUp($"{RandomString(12)}@supabase.io", PASSWORD);
+		session.Should().NotBeNull();
+		session!.User?.Id.Should().NotBeNullOrEmpty();
+		return new SignUpResult(session, session.User!.Id!);
+	}
+
+	private async Task VerifyRefreshFailsAndDestroysSession()
+	{
+		var refresh = () => client.RefreshSession();
+		var exception = await refresh.Should().ThrowAsync<GotrueException>();
+		exception.Which.Reason.Should().Be(InvalidRefreshToken);
+		client.CurrentSession.Should().BeNull();
+	}
+
+	private void ExpireCurrentSession()
+	{
+		client.CurrentSession.Should().NotBeNull();
+		client.CurrentSession!.CreatedAt = DateTime.UtcNow.AddDays(-1);
+	}
+
+	private async Task VerifyRotatedSession(SignUpResult signUp, Session refreshed)
+	{
+		refreshed.Should().NotBeNull();
+		refreshed.RefreshToken.Should().NotBe(signUp.Session.RefreshToken);
+		stateChanges.Should().Contain(TokenRefreshed);
+		persistence.SavedSession.Should().BeSameAs(client.CurrentSession);
+		var user = await client.GetUser(refreshed.AccessToken!);
+		user.Should().NotBeNull();
+		user!.Id.Should().Be(signUp.UserId);
+	}
+}

--- a/GotrueTests/TokenRefresh/RefreshBehaviorTests.cs
+++ b/GotrueTests/TokenRefresh/RefreshBehaviorTests.cs
@@ -55,10 +55,8 @@ public class RefreshBehaviorTests
 	{
 		await SignUpNewUser();
 		client.CurrentSession!.RefreshToken = rejectedToken;
-
 		Func<Task> refresh = () => client.RefreshSession();
 		var exception = await refresh.Should().ThrowAsync<GotrueException>();
-
 		exception.Which.Reason.Should().Be(InvalidRefreshToken);
 		client.CurrentSession.Should().BeNull();
 	}

--- a/GotrueTests/TokenRefresh/RefreshContractTests.cs
+++ b/GotrueTests/TokenRefresh/RefreshContractTests.cs
@@ -1,0 +1,104 @@
+#region
+
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GotrueTests.Support;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Supabase.Gotrue;
+using Supabase.Gotrue.Exceptions;
+using Supabase.Gotrue.Interfaces;
+using static Supabase.Gotrue.Exceptions.FailureHint.Reason;
+
+#endregion
+
+namespace GotrueTests.TokenRefresh;
+
+[TestClass]
+[TestCategory("Contract")]
+public class RefreshContractTests
+{
+	private const string AccessToken = "an-access-token";
+	private const string RefreshTokenValue = "a-refresh-token";
+	private const string UnclassifiedError = "{\"msg\":\"internal server error\"}";
+	private const string TokenNotFoundError = "{\"code\":400,\"error_code\":\"refresh_token_not_found\",\"msg\":\"Invalid Refresh Token: Refresh Token Not Found\"}";
+	private const string MalformedTokenError = "{\"code\":400,\"error_code\":\"validation_failed\",\"msg\":\"Refresh token is not valid\"}";
+	private IGotrueClient<User, Session> client;
+	private MockGotrueServer server;
+
+	[TestInitialize]
+	public void TestInitializer()
+	{
+		server = new MockGotrueServer();
+		client = TestClients.Against(server);
+	}
+
+	[TestCleanup]
+	public void TestCleanup()
+	{
+		server.Dispose();
+	}
+
+	[TestMethod("Refresh sends POST /token?grant_type=refresh_token with bearer auth, the api key, and only the refresh token as body")]
+	public async Task RefreshSendsExpectedRequest()
+	{
+		MockSuccessResponse();
+		await client.RefreshToken(AccessToken, RefreshTokenValue);
+		server.VerifySingleReceivedRequest()
+			.WithMethod(HttpMethod.Post)
+			.WithPath("/token")
+			.WithQueryParam("grant_type", "refresh_token")
+			.WithHeader("Authorization", $"Bearer {AccessToken}")
+			.WithHeader("apikey", MockGotrueServer.ApiKey)
+			.WithJsonContentType()
+			.WithExactJsonBody("refresh_token", RefreshTokenValue);
+	}
+
+	[TestMethod("A successful refresh response becomes the current session")]
+	public async Task RefreshMapsResponseToSession()
+	{
+		MockSuccessResponse();
+		await client.RefreshToken(AccessToken, RefreshTokenValue);
+		ValidateCurrentSessionPropertiesVerifyRefreshedToken();
+	}
+
+
+	[DataTestMethod("A 400 invalid-refresh-token response is classified as InvalidRefreshToken and destroys the session")]
+	[DataRow(TokenNotFoundError, DisplayName = "unknown token (refresh_token_not_found)")]
+	[DataRow(MalformedTokenError, DisplayName = "malformed token (validation_failed)")]
+	public async Task InvalidRefreshTokenResponseIsClassified(string errorBody)
+	{
+		MockErrorResponse(400, errorBody);
+		var refresh = () => client.RefreshToken(AccessToken, RefreshTokenValue);
+		var exception = await refresh.Should().ThrowAsync<GotrueException>();
+		exception.Which.Reason.Should().Be(InvalidRefreshToken);
+		client.CurrentSession.Should().BeNull();
+	}
+
+	[TestMethod("An unrecognized error response is classified as Unknown")]
+	public async Task UnrecognizedErrorResponseIsUnknown()
+	{
+		MockErrorResponse(500, UnclassifiedError);
+		var refresh = () => client.RefreshToken(AccessToken, RefreshTokenValue);
+		var exception = await refresh.Should().ThrowAsync<GotrueException>();
+		exception.Which.Reason.Should().Be(Unknown);
+		client.CurrentSession.Should().BeNull();
+	}
+
+	private void MockSuccessResponse() =>
+		server.RespondsTo("/token", 200,
+			"{\"access_token\":\"new-access-token\",\"refresh_token\":\"new-refresh-token\",\"token_type\":\"bearer\",\"expires_in\":3600,\"user\":{\"id\":\"user-id-123\",\"aud\":\"authenticated\"}}");
+
+	private void MockErrorResponse(int statusCode, string body) =>
+		server.RespondsTo("/token", statusCode, body);
+	
+	private void ValidateCurrentSessionPropertiesVerifyRefreshedToken()
+	{
+		client.CurrentSession.Should().NotBeNull();
+		client.CurrentSession!.AccessToken.Should().Be("new-access-token");
+		client.CurrentSession!.RefreshToken.Should().Be("new-refresh-token");
+		client.CurrentSession!.User.Should().NotBeNull();
+		client.CurrentSession!.User?.Id.Should().Be("user-id-123");
+		client.CurrentSession!.ExpiresIn.Should().Be(3600);
+	}
+}

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,56 @@
+# Minimal Supabase CLI stack for the Behavior test tier (GotrueTests/TokenRefresh).
+# Only api (Kong), db, and auth are enabled; everything else is switched off to keep
+# `supabase start` fast in CI. Keys/URL are the CLI defaults expected by
+# GotrueTests/Support/TestClients.cs (overridable via SUPABASE_CLI_AUTH_URL / SUPABASE_CLI_ANON_KEY).
+project_id = "gotrue-csharp"
+
+[api]
+enabled = true
+port = 54321
+schemas = ["public", "graphql_public"]
+extra_search_path = ["public", "extensions"]
+max_rows = 1000
+
+[db]
+port = 54322
+shadow_port = 54320
+major_version = 17
+
+[db.pooler]
+enabled = false
+
+[db.migrations]
+enabled = true
+
+[db.seed]
+enabled = false
+
+[realtime]
+enabled = false
+
+[studio]
+enabled = false
+
+[local_smtp]
+enabled = false
+
+[storage]
+enabled = false
+
+[auth]
+enabled = true
+site_url = "http://127.0.0.1:3000"
+jwt_expiry = 3600
+enable_refresh_token_rotation = true
+refresh_token_reuse_interval = 10
+enable_signup = true
+
+[auth.email]
+enable_signup = true
+enable_confirmations = false
+
+[edge_runtime]
+enabled = false
+
+[analytics]
+enabled = false


### PR DESCRIPTION
## Classification fix

Current gotrue (since supabase/auth#2216) validates the refresh token format before the database lookup, so rejections come from two paths with different bodies:

- Malformed token: `{"error_code":"validation_failed","msg":"Refresh token is not valid"}`
- Well-formed but unknown/revoked token: `{"error_code":"refresh_token_not_found","msg":"Invalid Refresh Token: Refresh Token Not Found"}`

`FailureHint.DetectReason` only matched the legacy `"Invalid Refresh Token"` message, so format rejections were classified as `Reason.Unknown` — and since `RefreshSession()`/`RefreshToken()` only destroy the session on `InvalidRefreshToken`, the client kept a dead session as `CurrentSession`. Both paths are now classified as `InvalidRefreshToken`, including a match on the stable `refresh_token_not_found` error code since the `msg` wording has already drifted between server versions.

`RefreshToken(accessToken, refreshToken)` is also now exposed on `IGotrueClient`. It has been `public` on `Client` since #72 and the same shape exists on `IGotrueStatelessClient`, but consumers of the umbrella `supabase-csharp` package only see `IGotrueClient`, so it was unreachable for them without downcasting. Note: source-breaking for hand-written implementations of the interface (dynamic mocks are unaffected).

## Test suite improvement

New `GotrueTests/TokenRefresh/` suite in two tiers, with shared fixtures in `GotrueTests/Support/`:

- **`RefreshContractTests`** (WireMock): pins the `POST /token?grant_type=refresh_token` exchange — request shape, response-to-session mapping, and classification of both rejection bodies.
- **`RefreshBehaviorTests`** (live Supabase CLI stack, gotrue v2.191.0): token rotation, expired-session refresh, and rejected tokens destroying the session. This tier is what surfaced the classification gap: the repo's docker-compose stack pins `gotrue:v2.155.6`, which predates format validation and always returns the legacy message. Endpoint and key are overridable via `SUPABASE_CLI_AUTH_URL` / `SUPABASE_CLI_ANON_KEY`.

Legacy tests fully superseded by the new suite were removed (`AnonKeyClientFailureTests` bogus/expired token, `AnonKeyClientTests` token-refreshed event); the persistence assertion unique to the latter moved into the new suite.

Updating the docker-compose stack to a current gotrue/postgres is deliberately left for a separate PR.

## Workflow update

The behavior tier needs a Supabase CLI stack on `127.0.0.1:54321`, but CI only started the legacy docker-compose stack (`:9999`), so those tests failed with connection refused on the runner. The workflow now installs the Supabase CLI and runs `supabase start` alongside the existing compose stack, backed by a minimal `supabase/config.toml` added to the repo (api, db, and auth only — everything else disabled for startup speed). The CLI's default URL and demo anon key are exactly what the test fixtures expect, so no secrets or environment wiring is required.
