### PR TITLE
fix: correct PKCE verifier/challenge swap in SignInWithOtp and ResetPasswordForEmail

### DIFF
--- a/Gotrue/Api.cs
+++ b/Gotrue/Api.cs
@@ -144,9 +144,8 @@ namespace Supabase.Gotrue
 
 			if (options.FlowType == OAuthFlowType.PKCE)
 			{
-				var challenge = Helpers.GenerateNonce();
-				verifier = Helpers.GeneratePKCENonceVerifier(challenge);
-
+				verifier = Helpers.GenerateNonce();
+				var challenge = Helpers.GeneratePKCENonceVerifier(verifier);
 				body.Add("code_challenge", challenge);
 				body.Add("code_challenge_method", "s256");
 			}
@@ -488,8 +487,8 @@ namespace Supabase.Gotrue
 
 			if (options.FlowType == OAuthFlowType.PKCE)
 			{
-				var challenge = Helpers.GenerateNonce();
-				verifier = Helpers.GeneratePKCENonceVerifier(challenge);
+				verifier = Helpers.GenerateNonce();
+				var challenge = Helpers.GeneratePKCENonceVerifier(verifier);
 
 				body.Add("code_challenge", challenge);
 				body.Add("code_challenge_method", "s256");

--- a/GotrueTests/GotrueTests.csproj
+++ b/GotrueTests/GotrueTests.csproj
@@ -22,4 +22,8 @@
   <ItemGroup>
     <ProjectReference Include="..\Gotrue\Gotrue.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <None Update="TokenRefresh\Fixtures\*.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
 </Project>

--- a/GotrueTests/PKCE/PkceContractTests.cs
+++ b/GotrueTests/PKCE/PkceContractTests.cs
@@ -1,0 +1,86 @@
+#region
+
+using System;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GotrueTests.Support;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Supabase.Gotrue;
+using Supabase.Gotrue.Interfaces;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using static Supabase.Gotrue.Constants;
+
+#endregion
+
+namespace GotrueTests.PKCE;
+
+[TestClass]
+[TestCategory("Contract")]
+public class PkceContractTests
+{
+	private IGotrueClient<User, Session> client;
+	private MockGotrueServer server;
+
+	[TestInitialize]
+	public void TestInitialize()
+	{
+		server = new MockGotrueServer();
+		client = TestClients.Against(server);
+	}
+
+	[TestCleanup]
+	public void TestCleanup() => server.Dispose();
+
+	[TestMethod("SignInWithOtp (email, PKCE): returns raw nonce as verifier and sends its SHA-256 hash as code_challenge")]
+	public async Task SignInWithOtpPkce_ChallengeIsHashOfVerifier()
+	{
+		server
+			.Given(Request.Create()
+				.WithPath("/otp")
+				.UsingPost())
+			.RespondWith(Response.Create()
+				.WithStatusCode(200)
+				.WithHeader("Content-Type", "application/json")
+				.WithBody("{}"));
+		var state = await client.SignInWithOtp(new SignInWithPasswordlessEmailOptions("test@example.com")
+		{
+			FlowType = OAuthFlowType.PKCE
+		});
+		
+		var request = server.VerifySingleReceivedRequest().WithMethod(HttpMethod.Post).WithPath("/otp");
+		request.ReadJsonBodyField("code_challenge_method").Should().Be("s256");
+		request.ReadJsonBodyField("code_challenge").Should().Be(S256(state.PKCEVerifier!), "server must receive BASE64URL(SHA256(verifier)) per RFC 7636 §4.2");
+	}
+
+	[TestMethod("ResetPasswordForEmail (PKCE): returns raw nonce as verifier and sends its SHA-256 hash as code_challenge")]
+	public async Task ResetPasswordForEmailPkce_ChallengeIsHashOfVerifier()
+	{
+		server
+			.Given(Request.Create()
+				.WithPath("/recover")
+				.UsingPost())
+			.RespondWith(Response.Create()
+				.WithStatusCode(200)
+				.WithHeader("Content-Type", "application/json")
+				.WithBody("{}"));
+		var state = await client.ResetPasswordForEmail(new ResetPasswordForEmailOptions("test@example.com")
+		{
+			FlowType = OAuthFlowType.PKCE
+		});
+
+		var request = server.VerifySingleReceivedRequest().WithMethod(HttpMethod.Post).WithPath("/recover");
+		request.ReadJsonBodyField("code_challenge_method").Should().Be("s256");
+		request.ReadJsonBodyField("code_challenge").Should().Be(S256(state.PKCEVerifier!), "server must receive BASE64URL(SHA256(verifier)) per RFC 7636 §4.2");
+	}
+
+	private static string S256(string verifier)
+	{
+		using var sha = SHA256.Create();
+		var hash = sha.ComputeHash(Encoding.UTF8.GetBytes(verifier));
+		return Convert.ToBase64String(hash).Replace('+', '-').Replace('/', '_').TrimEnd('=');
+	}
+}

--- a/GotrueTests/Support/MockGotrueServer.cs
+++ b/GotrueTests/Support/MockGotrueServer.cs
@@ -18,13 +18,8 @@ namespace GotrueTests.Support
 
 		internal string Url => server.Url!;
 
-		internal void RespondsTo(string path, int statusCode, string jsonBody) =>
-			server
-				.Given(Request.Create().WithPath(path))
-				.RespondWith(Response.Create()
-					.WithStatusCode(statusCode)
-					.WithHeader("Content-Type", "application/json")
-					.WithBody(jsonBody));
+		internal IRespondWithAProvider Given(IRequestBuilder requestBuilder) =>
+			server.Given(requestBuilder);
 
 		internal ReceivedRequest VerifySingleReceivedRequest()
 		{
@@ -79,6 +74,13 @@ namespace GotrueTests.Support
 			request.Body.Should().NotBeNull("the request should have a body");
 			var body = JObject.Parse(request.Body);
 			((string)body[field]).Should().Be(expected);
+		}
+
+		internal string ReadJsonBodyField(string field)
+		{
+			request.Body.Should().NotBeNull("the request should have a body");
+			var body = JObject.Parse(request.Body);
+			return (string)body[field];
 		}
 	}
 }

--- a/GotrueTests/TokenRefresh/Fixtures/malformed_token_error.json
+++ b/GotrueTests/TokenRefresh/Fixtures/malformed_token_error.json
@@ -1,0 +1,5 @@
+{
+  "code": 400,
+  "error_code": "validation_failed",
+  "msg": "Refresh token is not valid"
+}

--- a/GotrueTests/TokenRefresh/Fixtures/token_not_found_error.json
+++ b/GotrueTests/TokenRefresh/Fixtures/token_not_found_error.json
@@ -1,0 +1,5 @@
+{
+  "code": 400,
+  "error_code": "refresh_token_not_found",
+  "msg": "Invalid Refresh Token: Refresh Token Not Found"
+}

--- a/GotrueTests/TokenRefresh/Fixtures/token_success.json
+++ b/GotrueTests/TokenRefresh/Fixtures/token_success.json
@@ -1,0 +1,10 @@
+{
+  "access_token": "new-access-token",
+  "refresh_token": "new-refresh-token",
+  "token_type": "bearer",
+  "expires_in": 3600,
+  "user": {
+    "id": "user-id-123",
+    "aud": "authenticated"
+  }
+}

--- a/GotrueTests/TokenRefresh/Fixtures/unclassified_error.json
+++ b/GotrueTests/TokenRefresh/Fixtures/unclassified_error.json
@@ -1,0 +1,3 @@
+{
+  "msg": "internal server error"
+}

--- a/GotrueTests/TokenRefresh/RefreshContractTests.cs
+++ b/GotrueTests/TokenRefresh/RefreshContractTests.cs
@@ -1,5 +1,7 @@
 #region
 
+using System;
+using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -8,6 +10,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Supabase.Gotrue;
 using Supabase.Gotrue.Exceptions;
 using Supabase.Gotrue.Interfaces;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
 using static Supabase.Gotrue.Exceptions.FailureHint.Reason;
 
 #endregion
@@ -20,9 +24,6 @@ public class RefreshContractTests
 {
 	private const string AccessToken = "an-access-token";
 	private const string RefreshTokenValue = "a-refresh-token";
-	private const string UnclassifiedError = "{\"msg\":\"internal server error\"}";
-	private const string TokenNotFoundError = "{\"code\":400,\"error_code\":\"refresh_token_not_found\",\"msg\":\"Invalid Refresh Token: Refresh Token Not Found\"}";
-	private const string MalformedTokenError = "{\"code\":400,\"error_code\":\"validation_failed\",\"msg\":\"Refresh token is not valid\"}";
 	private IGotrueClient<User, Session> client;
 	private MockGotrueServer server;
 
@@ -34,10 +35,7 @@ public class RefreshContractTests
 	}
 
 	[TestCleanup]
-	public void TestCleanup()
-	{
-		server.Dispose();
-	}
+	public void TestCleanup() => server.Dispose();
 
 	[TestMethod("Refresh sends POST /token?grant_type=refresh_token with bearer auth, the api key, and only the refresh token as body")]
 	public async Task RefreshSendsExpectedRequest()
@@ -59,16 +57,20 @@ public class RefreshContractTests
 	{
 		MockSuccessResponse();
 		await client.RefreshToken(AccessToken, RefreshTokenValue);
-		ValidateCurrentSessionPropertiesVerifyRefreshedToken();
+		client.CurrentSession.Should().NotBeNull();
+		client.CurrentSession!.AccessToken.Should().Be("new-access-token");
+		client.CurrentSession!.RefreshToken.Should().Be("new-refresh-token");
+		client.CurrentSession!.User.Should().NotBeNull();
+		client.CurrentSession!.User?.Id.Should().Be("user-id-123");
+		client.CurrentSession!.ExpiresIn.Should().Be(3600);
 	}
 
-
 	[DataTestMethod("A 400 invalid-refresh-token response is classified as InvalidRefreshToken and destroys the session")]
-	[DataRow(TokenNotFoundError, DisplayName = "unknown token (refresh_token_not_found)")]
-	[DataRow(MalformedTokenError, DisplayName = "malformed token (validation_failed)")]
-	public async Task InvalidRefreshTokenResponseIsClassified(string errorBody)
+	[DataRow("token_not_found_error.json", DisplayName = "unknown token (refresh_token_not_found)")]
+	[DataRow("malformed_token_error.json", DisplayName = "malformed token (validation_failed)")]
+	public async Task InvalidRefreshTokenResponseIsClassified(string fixture)
 	{
-		MockErrorResponse(400, errorBody);
+		MockErrorResponse(400, Fixture(fixture));
 		var refresh = () => client.RefreshToken(AccessToken, RefreshTokenValue);
 		var exception = await refresh.Should().ThrowAsync<GotrueException>();
 		exception.Which.Reason.Should().Be(InvalidRefreshToken);
@@ -78,7 +80,7 @@ public class RefreshContractTests
 	[TestMethod("An unrecognized error response is classified as Unknown")]
 	public async Task UnrecognizedErrorResponseIsUnknown()
 	{
-		MockErrorResponse(500, UnclassifiedError);
+		MockErrorResponse(500, Fixture("unclassified_error.json"));
 		var refresh = () => client.RefreshToken(AccessToken, RefreshTokenValue);
 		var exception = await refresh.Should().ThrowAsync<GotrueException>();
 		exception.Which.Reason.Should().Be(Unknown);
@@ -86,19 +88,21 @@ public class RefreshContractTests
 	}
 
 	private void MockSuccessResponse() =>
-		server.RespondsTo("/token", 200,
-			"{\"access_token\":\"new-access-token\",\"refresh_token\":\"new-refresh-token\",\"token_type\":\"bearer\",\"expires_in\":3600,\"user\":{\"id\":\"user-id-123\",\"aud\":\"authenticated\"}}");
+		server
+			.Given(Request.Create().WithPath("/token").UsingPost())
+			.RespondWith(Response.Create()
+				.WithStatusCode(200)
+				.WithHeader("Content-Type", "application/json")
+				.WithBody(Fixture("token_success.json")));
 
 	private void MockErrorResponse(int statusCode, string body) =>
-		server.RespondsTo("/token", statusCode, body);
-	
-	private void ValidateCurrentSessionPropertiesVerifyRefreshedToken()
-	{
-		client.CurrentSession.Should().NotBeNull();
-		client.CurrentSession!.AccessToken.Should().Be("new-access-token");
-		client.CurrentSession!.RefreshToken.Should().Be("new-refresh-token");
-		client.CurrentSession!.User.Should().NotBeNull();
-		client.CurrentSession!.User?.Id.Should().Be("user-id-123");
-		client.CurrentSession!.ExpiresIn.Should().Be(3600);
-	}
+		server
+			.Given(Request.Create().WithPath("/token").UsingPost())
+			.RespondWith(Response.Create()
+				.WithStatusCode(statusCode)
+				.WithHeader("Content-Type", "application/json")
+				.WithBody(body));
+
+	private static string Fixture(string name) =>
+		File.ReadAllText(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "TokenRefresh", "Fixtures", name));
 }


### PR DESCRIPTION
Fixes #126.

## What

`SignInWithOtp` (email) and `ResetPasswordForEmail` had the verifier and challenge assigned to the wrong variables. The raw nonce was sent to the server as `code_challenge`, and the SHA-256 hash was returned as `PKCEVerifier`. Since the server validates `SHA256(received_verifier) == stored_challenge`, this always produced a 400 on `ExchangeCodeForSession`.

`SignInWithProvider` in `Helpers.cs` already had the correct implementation and was used as reference.

## Fix

Swap the two lines in each method so the nonce is the verifier and its hash is the challenge, matching RFC 7636 S256.

## Tests

Added `PkceContractTests` (contract tier, WireMock) with one test per fixed method. Each test verifies that `code_challenge` sent to the server equals `BASE64URL(SHA256(PKCEVerifier))`, computed independently using raw BCL SHA256 — not the SDK helper — to avoid any circular dependency.