### PR TITLE
feat: add state parameter support to OAuth provider sign-in

### DIFF
--- a/Gotrue/Helpers.cs
+++ b/Gotrue/Helpers.cs
@@ -108,6 +108,10 @@ namespace Supabase.Gotrue
 			if (attr == null)
 				throw new Exception("Unknown provider");
 
+			var state = !string.IsNullOrEmpty(options.State) ? options.State : GenerateNonce();
+			query.Add("state", state);
+			result.State = state;
+
 			query.Add("provider", attr.Mapping);
 
 			if (!string.IsNullOrEmpty(options.Scopes))

--- a/Gotrue/ProviderAuthState.cs
+++ b/Gotrue/ProviderAuthState.cs
@@ -19,6 +19,12 @@ namespace Supabase.Gotrue
         public string? PKCEVerifier { get; set; }
 
         /// <summary>
+        /// The state parameter included in the OAuth URL for CSRF protection (RFC 6749 §10.12).
+        /// Validate this against the state echoed back in the OAuth callback.
+        /// </summary>
+        public string State { get; set; } = null!;
+
+        /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="uri"></param>

--- a/Gotrue/SignInOptions.cs
+++ b/Gotrue/SignInOptions.cs
@@ -29,5 +29,13 @@ namespace Supabase.Gotrue
         /// PKCE is recommended for mobile and server-side applications.
         /// </summary>
         public OAuthFlowType FlowType { get; set; } = OAuthFlowType.Implicit;
+
+        /// <summary>
+        /// An optional state parameter for CSRF protection (RFC 6749 §10.12).
+        /// If not provided, one will be generated automatically.
+        /// Store the returned <see cref="ProviderAuthState.State"/> value and validate it
+        /// against the state echoed back in the OAuth callback.
+        /// </summary>
+        public string? State { get; set; }
     }
 }

--- a/GotrueTests/AnonKeyClientTests.cs
+++ b/GotrueTests/AnonKeyClientTests.cs
@@ -243,10 +243,14 @@ namespace GotrueTests
 		public async Task ClientReturnsAuthUrlForProvider()
 		{
 			var result1 = await _client.SignIn(Constants.Provider.Google);
-			AreEqual($"{TestClients.CliAuthUrl}/authorize?provider=google", result1.Uri.ToString());
+			IsTrue(result1.Uri.ToString().StartsWith($"{TestClients.CliAuthUrl}/authorize"));
+			IsTrue(result1.Uri.Query.Contains("provider=google"));
+			IsTrue(result1.Uri.Query.Contains("state="));
 
 			var result2 = await _client.SignIn(Constants.Provider.Google, new SignInOptions { Scopes = "special scopes please" });
-			AreEqual($"{TestClients.CliAuthUrl}/authorize?provider=google&scopes=special+scopes+please", result2.Uri.ToString());
+			IsTrue(result2.Uri.Query.Contains("provider=google"));
+			IsTrue(result2.Uri.Query.Contains("scopes=special+scopes+please"));
+			IsTrue(result2.Uri.Query.Contains("state="));
 		}
 
 		[TestMethod("Client: Returns Verification Code for Provider")]

--- a/GotrueTests/PKCE/PkceContractTests.cs
+++ b/GotrueTests/PKCE/PkceContractTests.cs
@@ -77,6 +77,27 @@ public class PkceContractTests
 		request.ReadJsonBodyField("code_challenge").Should().Be(S256(state.PKCEVerifier!), "server must receive BASE64URL(SHA256(verifier)) per RFC 7636 §4.2");
 	}
 
+	[TestMethod("SignInWithProvider: auto-generates state and includes it in the URL")]
+	public async Task SignInWithProvider_AutoGeneratesState()
+	{
+		var result = await client.SignIn(Provider.Github, new SignInOptions { FlowType = OAuthFlowType.PKCE });
+		result.State.Should().NotBeNullOrEmpty();
+		result.Uri.Query.Should().Contain($"state={result.State}");
+	}
+
+	[TestMethod("SignInWithProvider: uses developer-provided state and includes it in the URL")]
+	public async Task SignInWithProvider_UsesDeveloperProvidedState()
+	{
+		var customState = "my-server-generated-csrf-token";
+		var result = await client.SignIn(Provider.Github, new SignInOptions
+		{
+			FlowType = OAuthFlowType.PKCE,
+			State = customState
+		});
+		result.State.Should().Be(customState);
+		result.Uri.Query.Should().Contain($"state={customState}");
+	}
+
 	private static string S256(string verifier)
 	{
 		using var sha = SHA256.Create();

--- a/GotrueTests/StatelessClientTests.cs
+++ b/GotrueTests/StatelessClientTests.cs
@@ -205,10 +205,14 @@ namespace GotrueTests
 		public void ReturnsAuthUrlForProvider()
 		{
 			var result1 = _client.SignIn(Provider.Google, Options);
-			Assert.AreEqual($"{TestClients.CliAuthUrl}/authorize?provider=google", result1.Uri.ToString());
+			Assert.IsTrue(result1.Uri.ToString().StartsWith($"{TestClients.CliAuthUrl}/authorize"));
+			Assert.IsTrue(result1.Uri.Query.Contains("provider=google"));
+			Assert.IsTrue(result1.Uri.Query.Contains("state="));
 
 			var result2 = _client.SignIn(Provider.Google, Options, new SignInOptions { Scopes = "special scopes please" });
-			Assert.AreEqual($"{TestClients.CliAuthUrl}/authorize?provider=google&scopes=special+scopes+please", result2.Uri.ToString());
+			Assert.IsTrue(result2.Uri.Query.Contains("provider=google"));
+			Assert.IsTrue(result2.Uri.Query.Contains("scopes=special+scopes+please"));
+			Assert.IsTrue(result2.Uri.Query.Contains("state="));
 		}
 
 		[TestMethod("StatelessClient: Update user")]


### PR DESCRIPTION
Fixes supabase-community/supabase-csharp#222.

## What

`SignIn(Provider, options)` had no way to include a `state` parameter in the OAuth URL. Without it, server-side callers had no CSRF protection and were forced to manually append state to the returned URL themselves.

## Fix

- Added `State` to `SignInOptions` — callers can provide their own value or leave it unset
- `GetUrlForProvider` always includes a `state` in the URL: the caller-provided value if set, otherwise an auto-generated nonce
- Added `State` to `ProviderAuthState` so the caller gets back whatever was used, ready to store and validate against the OAuth callback

## What this doesn't do

State validation is the caller's responsibility — the SDK just ensures the value is in the URL and returned. Storage and comparison against the callback are outside the SDK's scope.